### PR TITLE
optimizations

### DIFF
--- a/Memory.h
+++ b/Memory.h
@@ -1,115 +1,155 @@
 #pragma once
+#include <iostream>
+#include <vector>
+#include <string>
+
+//	External Libraries
 #include <leechcore.h>
 #include <vmmdll.h>
-#include <vector>
+
+#define PROCESS_NAME ""								//
+inline VMM_HANDLE pHandle{ nullptr };				//	obtained on PCIMemory class construction
+
+struct PCIProcess
+{
+	DWORD			dwProcID;
+	__int64			dwModBase;
+	__int64			dwPEB;
+	std::string		dwProcName;
+	VMMDLL_PROCESS_INFORMATION vmProcessInfo;
+};
+inline PCIProcess vmProcess;						//	generated on PCIMemory class construction
+
+// Argument values for function returns
+#define PCI_SUCCESS 1
+#define PCI_FAILURE 0
+#define PCI_ERROR -1
 
 class PCIMemory
 {
 public:
 
 	/*
-	 *
-	 *
+	*	[RAW FUNCTIONS]
+	* Contains most of the heavy logic and must be utilized with the default constructor
+	* 
+	* 
 	*/
-	static bool				InitProcess(const char* procName);
-	
-	/*
-	 *
-	 *
-	*/
-	static DWORD			GetProcID();
-	static bool				GetProcID(const char* name, int& dwPID);
-	
-	/*
-	 *
-	 *
-	*/
-	static bool				GetProcInfo(int dwPID, VMMDLL_PROCESS_INFORMATION& result);
-	static bool				GetProcInfo(VMMDLL_PROCESS_INFORMATION& result);
-	
-	/*
-	 *
-	 *
-	*/
-	static __int64			GetModuleBase();
-	static __int64			GetModuleBase(const char* name);
-	static __int64			GetModuleBase(int dwPID, const char* name);
-	
-	/*
-	 *
-	 *
-	*/
-	static __int64			GetProcPEB();
-	static __int64			GetProcPEB(int dwPID);
-	
-	/*
-	 *
-	 *
-	*/
-	static bool				ReadVirtualMemory(__int64 pAddress, LPVOID lResult, DWORD cbSize);
-	static bool				ReadVirtualMemory(int dwPID, __int64 pAddress, LPVOID lResult, DWORD cbSize);
+	static void				PCI_Init(LPSTR* args, DWORD cType, VMM_HANDLE& vmHandle);
+	static void				PCI_InitProcess(LPSTR* args, DWORD cType, const char* procName);
+	static bool				PCI_GetProcessID(const char* name, DWORD& dwPID);
+	static __int64			PCI_GetModuleBase(int dwPID, const char* name);
+	static __int64			PCI_GetProcPEB(int dwPID);
+	static __int64			PCI_GetProcAddress(int dwPID, const char* name, const char* fn);
+	static bool				PCI_GetProcDirectory(int dwPID, const char* modName, std::string& out);
+	static bool				PCI_GetProcInfo(int dwPID, VMMDLL_PROCESS_INFORMATION& result);
+	static bool				PCI_ReadVirtualMemory(int dwPID, __int64 pAddress, LPVOID lResult, DWORD cbSize);
+	static bool				PCI_ReadVirtualMemoryEx(int dwPID, __int64 pAddress, LPVOID lResult, DWORD cbSize);
+	static bool				PCI_WriteVirtualMemory(int dwPID, __int64 pAddress, LPVOID patch, DWORD cbSize);
+	static __int64			PCI_ResolvePtrChain(int dwPID, __int64 base, DWORD offsets[], int count);
+	static bool				PCI_DumpModule(int dwPID, const char* modName, std::vector<char>& out);
+	static bool				PCI_DumpBytes(int dwPID, __int64 lpAddress, DWORD cbSize, std::vector<char>& out);
+	static bool				PCI_DumpSectionToFile(int dwPID, const char* fileName, __int64 addr, DWORD cbSize);
+	static bool				PCI_DumpModuleToFile(int dwPID, const char* modName);
+	static bool				PCI_DumpModuleToFileA(int dwPID, const char* path, const char* modName);
+	static void				PCI_PrintSectionMemory(int dwPID, __int64 addr, DWORD cbSize);
 
-	/*
-	 *
-	 *
-	*/
-	static bool				WriteVirtualMemory(__int64 pAddress, LPVOID patch, DWORD cbSize);
-	static bool				WriteVirtualMemory(int dwPID, __int64 pAddress, LPVOID patch, DWORD cbSize);
-	
-	/*
-	 *
-	 *
-	*/
-	static __int64			ResolvePtrChain(__int64 base, DWORD offsets[], int count);
-	static __int64			ResolvePtrChain(int dwPID, __int64 base, DWORD offsets[], int count);
-
-	/*
-	 *
-	 *
-	*/
-	static bool				MapSectionMemory(char* xBytes, LPVOID& pOut, DWORD cbSize);
-
-	/*
-	 *
-	 *
-	*/
-	static bool				FreeMapSection(LPVOID pData, DWORD cbSize);
-
-	/*
-	 *
-	 *
-	*/
-	static bool				DumpModule(int dwPID, const char* modName, std::vector<char>& out);
-	static bool				DumpBytes(int dwPID, __int64 lpAddress, DWORD cbSize, std::vector<char>& out);
-
-	/*
-	 *
-	 *
-	*/
-	static void				PrintSectionMemory(int dwPID, __int64 addr, DWORD cbSize);
-	static void				PrintSectionMemory(std::vector<char> bytes, __int64 addr);
-
-
-	/*
-	 *
-	 *
-	*/
 	template<typename T>
-	static T Read(int dwPID, __int64 address)
+	static T PCI_Read(int dwPID, __int64 address, DWORD cbSize)
 	{
-		T result{ 0 };
-		ReadVirtualMemory(dwPID, address, &result, sizeof(result));
+		T result;
+		PCI_ReadVirtualMemory(dwPID, address, &result, cbSize);
 		return result;
 	}
-	
-	/*
-	 *
-	 *
-	*/
+
 	template<typename T>
-	static bool Write(int dwPID, __int64 address, T patch)
+	static T PCI_Read(int dwPID, __int64 address)
 	{
-		return WriteVirtualMemory(dwPID, address, patch, sizeof(patch));
+		T result{ 0 };
+		PCI_ReadVirtualMemory(dwPID, address, &result, sizeof(result));
+		return result;
+	}
+
+	template<typename T>
+	static T PCI_ReadEx(int dwPID, __int64 address)
+	{
+		T result;
+		PCI_ReadVirtualMemoryEx(dwPID, address, &result, sizeof(result));
+		return result;
+	}
+
+	template<typename T>
+	static bool PCI_Write(int dwPID, __int64 address, T patch, DWORD cbSize)
+	{
+		return PCI_WriteVirtualMemory(dwPID, address, &patch, cbSize);
+	}
+
+	template<typename T>
+	static bool PCI_Write(int dwPID, __int64 address, T patch)
+	{
+		return PCI_WriteVirtualMemory(dwPID, address, &patch, sizeof(patch));
+	}
+
+	/*
+	*
+	*/
+	static void				PrintSectionMemory(std::vector<char> bytes, __int64 addr);
+	static bool				MapSectionMemory(char* xBytes, LPVOID& pOut, DWORD cbSize);
+	static bool				FreeMapSection(LPVOID pData, DWORD cbSize);
+
+	/**/
+	static DWORD			GetProcID();
+	static __int64			GetModuleBase();
+	static __int64			GetModuleBase(const char* name);
+	static __int64			GetProcPEB();
+	static bool				GetProcInfo(VMMDLL_PROCESS_INFORMATION& result);
+	static bool				ReadVirtualMemory(__int64 pAddress, LPVOID lResult, DWORD cbSize);
+	static bool				ReadVirtualMemoryEx(__int64 pAddress, LPVOID lResult, DWORD cbSize);
+	static bool				WriteVirtualMemory(__int64 pAddress, LPVOID patch, DWORD cbSize);
+	static __int64			ResolvePtrChain(__int64 base, DWORD offsets[], int count);
+
+	template<typename T>
+	static T Read(__int64 address, DWORD cbSize)
+	{
+		T result;
+		ReadVirtualMemory(address, &result, cbSize);
+		return result;
+	}
+
+	template<typename T>
+	static T Read(__int64 address)
+	{
+		T result;
+		ReadVirtualMemory(address, &result, sizeof(result));
+		return result;
+	}
+
+	template<typename T>
+	static T ReadEx(__int64 address, DWORD cbSize)
+	{
+		T result;
+		ReadVirtualMemoryEx(address, &result, cbSize);
+		return result;
+	}
+
+	template<typename T>
+	static T ReadEx(__int64 address)
+	{
+		T result;
+		ReadVirtualMemoryEx(address, &result, sizeof(result));
+		return result;
+	}
+
+	template<typename T>
+	static bool Write(__int64 address, T patch, DWORD cbSize)
+	{
+		return WriteVirtualMemory(address, &patch, cbSize);
+	}
+
+	template<typename T>
+	static bool Write(__int64 address, T patch)
+	{
+		return WriteVirtualMemory(address, &patch, sizeof(patch));
 	}
 
 	/*
@@ -141,7 +181,8 @@ public:
 	PCIMemory(LPSTR* args, const char* procName, DWORD mType = 3);
 
 	/*
-	 *
+	 *	Deconstructor is automatically handled when the intializing instance is out of scope.
+	 * 
 	 *
 	*/
 	~PCIMemory();

--- a/PCIMemory.vcxproj
+++ b/PCIMemory.vcxproj
@@ -19,7 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="LICENSE" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Memory.cpp" />
   </ItemGroup>

--- a/main.cpp
+++ b/main.cpp
@@ -1,18 +1,29 @@
 #pragma once
 #include "Memory.h"
 
-#define PROCESS_NAME ""
-
 //	EXAMPLE
 int main()
 {
-
 	// INIT
-	PCIMemory mem = PCIMemory(PROCESS_NAME);	//	Memory.cpp ~28
+	//	-	NOTE: Initializing PCIMemory with a process name will populate a static structure 'vmProcess' containing basic process information
+	PCIMemory mem = PCIMemory(PROCESS_NAME);	//	Memory.cpp ~16
+	auto procInfo = vmProcess;	//	copy of 'vmProcess' structure, use to compare with the following calls
 
 	// PID
-	DWORD dwPID = PCIMemory::GetProcID();
+	//	- Returns vmProcess structure Process ID
+	DWORD dwPID = PCIMemory::GetProcID();	
 
+	// MODULE
+	//	- Returns vmProcess structure Module Base Address
+	__int64 dwMODULE = PCIMemory::GetModuleBase();
+	
+	// RESOURCE MODULE
+	//	- Returns module base address for ntdll module in the selected process ( if found )
+	__int64 dwNTDLL = PCIMemory::GetModuleBase("ntdll.dll");
 
+	//	PROCESS PEB
+	//	- returns process peb address which is stored in the vmProcess structure
+	__int64 dwPEB = PCIMemory::GetProcPEB();
 
+	return EXIT_SUCCESS;	//	PCIMemory should automaticall deconstuct
 }


### PR DESCRIPTION
CHANGES OVERVIEW
- Rename core functions
- Create structure for maintaining process information
- Optimize class constructor
- Include initialization functions
- include ease of use functions which make use of core methods

BUG FIXES
- WriteVirtualMemory

dump to file

fix: C2440

error: 'initializing' : cannot convert from 'type1' to 'type2'

resolved by removing template type initializer in template read methods